### PR TITLE
Restore CI and Update Dependencies to Major Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import vercelStatic from '@astrojs/vercel';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
+import { unified } from '@astrojs/markdown-remark';
+
 const options = {
 	// Specify the theme to use or a custom theme json, in our case
 	// it will be a moonlight-II theme from
@@ -35,9 +37,10 @@ export default defineConfig({
 
 	markdown: {
 		syntaxHighlight: false,
-		// Disable syntax built-in syntax hightlighting from astro
-		rehypePlugins: [[rehypePrettyCode, options]],
-		remarkPlugins: [remarkReadingTime]
+		processor: unified({
+			rehypePlugins: [[rehypePrettyCode, options]],
+			remarkPlugins: [remarkReadingTime]
+		})
 	},
 
 	integrations: [react(), sitemap()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,36 +8,39 @@
 			"name": "vigorous-virgo",
 			"version": "0.0.1",
 			"dependencies": {
-				"@astrojs/check": "0.9.9",
-				"@astrojs/react": "4.4.2",
+				"@astrojs/markdown-remark": "7.2.0",
+				"@astrojs/react": "6.0.0",
 				"@astrojs/rss": "4.0.18",
 				"@astrojs/sitemap": "3.7.3",
-				"@astrojs/vercel": "9.0.5",
-				"@tailwindcss/vite": "4.3.1",
-				"@types/react": "19.2.17",
-				"@types/react-dom": "19.2.3",
-				"@vercel/analytics": "1.6.1",
-				"astro": "5.18.2",
+				"@astrojs/vercel": "11.0.0",
+				"@vercel/analytics": "2.0.1",
+				"astro": "7.0.3",
 				"canvas-confetti": "1.9.4",
 				"mdast-util-to-string": "4.0.0",
 				"react": "19.2.7",
 				"react-dom": "19.2.7",
 				"reading-time": "1.5.0",
-				"rehype-pretty-code": "0.14.3",
-				"tailwindcss": "4.3.1",
-				"typescript": "5.9.3"
+				"rehype-pretty-code": "0.14.3"
 			},
 			"devDependencies": {
+				"@astrojs/check": "0.9.9",
 				"@tailwindcss/typography": "0.5.20",
+				"@tailwindcss/vite": "4.3.1",
+				"@types/react": "19.2.17",
+				"@types/react-dom": "19.2.3",
 				"prettier": "3.8.4",
 				"prettier-plugin-astro": "0.14.1",
-				"prettier-plugin-tailwindcss": "0.8.0"
+				"prettier-plugin-tailwindcss": "0.8.0",
+				"tailwindcss": "4.3.1",
+				"typescript": "6.0.3",
+				"vite": "7.3.3"
 			}
 		},
 		"node_modules/@astrojs/check": {
 			"version": "0.9.9",
 			"resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
 			"integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/language-server": "^2.16.7",
@@ -56,18 +59,215 @@
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
 			"integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@astrojs/compiler-binding": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.2.3.tgz",
+			"integrity": "sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw==",
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@astrojs/compiler-binding-darwin-arm64": "0.2.3",
+				"@astrojs/compiler-binding-darwin-x64": "0.2.3",
+				"@astrojs/compiler-binding-linux-arm64-gnu": "0.2.3",
+				"@astrojs/compiler-binding-linux-arm64-musl": "0.2.3",
+				"@astrojs/compiler-binding-linux-x64-gnu": "0.2.3",
+				"@astrojs/compiler-binding-linux-x64-musl": "0.2.3",
+				"@astrojs/compiler-binding-wasm32-wasi": "0.2.3",
+				"@astrojs/compiler-binding-win32-arm64-msvc": "0.2.3",
+				"@astrojs/compiler-binding-win32-x64-msvc": "0.2.3"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-darwin-arm64": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.2.3.tgz",
+			"integrity": "sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-darwin-x64": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.2.3.tgz",
+			"integrity": "sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.2.3.tgz",
+			"integrity": "sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.2.3.tgz",
+			"integrity": "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.2.3.tgz",
+			"integrity": "sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.2.3.tgz",
+			"integrity": "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.2.3.tgz",
+			"integrity": "sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.2.3.tgz",
+			"integrity": "sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.2.3.tgz",
+			"integrity": "sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@astrojs/compiler-rs": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.2.3.tgz",
+			"integrity": "sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA==",
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/compiler-binding": "0.2.3"
+			}
+		},
 		"node_modules/@astrojs/internal-helpers": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
-			"integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-			"license": "MIT"
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+			"integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
+			}
 		},
 		"node_modules/@astrojs/language-server": {
 			"version": "2.16.10",
 			"resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
 			"integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/compiler": "^2.13.1",
@@ -106,18 +306,16 @@
 			}
 		},
 		"node_modules/@astrojs/markdown-remark": {
-			"version": "6.3.11",
-			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
-			"integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+			"integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.7.6",
-				"@astrojs/prism": "3.3.0",
+				"@astrojs/internal-helpers": "0.10.0",
+				"@astrojs/prism": "4.0.2",
 				"github-slugger": "^2.0.0",
 				"hast-util-from-html": "^2.0.3",
 				"hast-util-to-text": "^4.0.2",
-				"import-meta-resolve": "^4.2.0",
-				"js-yaml": "^4.1.1",
 				"mdast-util-definitions": "^6.0.0",
 				"rehype-raw": "^7.0.0",
 				"rehype-stringify": "^10.0.1",
@@ -125,122 +323,134 @@
 				"remark-parse": "^11.0.0",
 				"remark-rehype": "^11.1.2",
 				"remark-smartypants": "^3.0.2",
-				"shiki": "^3.21.0",
-				"smol-toml": "^1.6.0",
 				"unified": "^11.0.5",
 				"unist-util-remove-position": "^5.0.0",
-				"unist-util-visit": "^5.0.0",
+				"unist-util-visit": "^5.1.0",
 				"unist-util-visit-parents": "^6.0.2",
 				"vfile": "^6.0.3"
 			}
 		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/core": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+		"node_modules/@astrojs/markdown-satteri": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz",
+			"integrity": "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.5"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-javascript": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-			"integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^4.3.4"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/langs": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/themes": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/@shikijs/types": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
-		"node_modules/@astrojs/markdown-remark/node_modules/shiki": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-			"integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/core": "3.23.0",
-				"@shikijs/engine-javascript": "3.23.0",
-				"@shikijs/engine-oniguruma": "3.23.0",
-				"@shikijs/langs": "3.23.0",
-				"@shikijs/themes": "3.23.0",
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
+				"@astrojs/internal-helpers": "0.10.0",
+				"@astrojs/prism": "4.0.2",
+				"github-slugger": "^2.0.0",
+				"satteri": "^0.9.1"
 			}
 		},
 		"node_modules/@astrojs/prism": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-			"integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+			"integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
 			"license": "MIT",
 			"dependencies": {
 				"prismjs": "^1.30.0"
 			},
 			"engines": {
-				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
+				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@astrojs/react": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
-			"integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-6.0.0.tgz",
+			"integrity": "sha512-jNf3kKE6KYXJbD5ZsXaLhnwDK3YvK9ttQ2ykAcNf5XdxOlUQEHLnomO3FO8abqghs0ilqhgGOyc2AlgGyQtz/g==",
 			"license": "MIT",
 			"dependencies": {
-				"@vitejs/plugin-react": "^4.7.0",
+				"@astrojs/internal-helpers": "0.10.0",
+				"@vitejs/plugin-react": "^5.2.0",
+				"devalue": "^5.8.1",
 				"ultrahtml": "^1.6.0",
-				"vite": "^6.4.1"
+				"vite": "^8.0.13"
 			},
 			"engines": {
-				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
+				"node": ">=22.12.0"
 			},
 			"peerDependencies": {
 				"@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
 				"@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@astrojs/react/node_modules/vite": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+			"integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.15",
+				"rolldown": "~1.1.2",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@astrojs/rss": {
@@ -266,17 +476,15 @@
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-			"integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+			"integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
 			"license": "MIT",
 			"dependencies": {
-				"ci-info": "^4.2.0",
-				"debug": "^4.4.0",
-				"dlv": "^1.1.3",
+				"ci-info": "^4.4.0",
 				"dset": "^3.1.4",
-				"is-docker": "^3.0.0",
-				"is-wsl": "^3.1.0",
+				"is-docker": "^4.0.0",
+				"is-wsl": "^3.1.1",
 				"which-pm-runs": "^1.1.0"
 			},
 			"engines": {
@@ -284,27 +492,523 @@
 			}
 		},
 		"node_modules/@astrojs/vercel": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-9.0.5.tgz",
-			"integrity": "sha512-rGuoVF/faLRcW1hE9Bu/DZPgaqk3TT6MzqiLsVemotecSSqZeSAh4+x7cNq7fLk75vS/dm14rO5V1lm+8Gp3dg==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-11.0.0.tgz",
+			"integrity": "sha512-Ii2o/45JaTdy0MULwzQQM8A4K7gkTTxQtj6b4ZghvTLdESBc0kGEIvd2ldAswYzbbSUqrspRgxOg/mu3D5qAAg==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.7.6",
+				"@astrojs/internal-helpers": "0.10.0",
 				"@vercel/analytics": "^1.6.1",
-				"@vercel/functions": "^2.2.13",
-				"@vercel/nft": "0.30.4",
-				"@vercel/routing-utils": "^5.3.2",
-				"esbuild": "^0.25.0",
+				"@vercel/functions": "^3.4.3",
+				"@vercel/nft": "^1.3.2",
+				"@vercel/routing-utils": "^5.3.3",
+				"esbuild": "^0.28.0",
 				"tinyglobby": "^0.2.15"
 			},
 			"peerDependencies": {
-				"astro": "^5.0.0"
+				"astro": "^7.0.0-alpha.0"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/@vercel/analytics": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+			"integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+			"license": "MPL-2.0",
+			"peerDependencies": {
+				"@remix-run/react": "^2",
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"svelte": ">= 4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
+				"@remix-run/react": {
+					"optional": true
+				},
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@astrojs/vercel/node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/@astrojs/yaml2ts": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
 			"integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"yaml": "^2.8.3"
@@ -591,6 +1295,131 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@bruits/satteri-darwin-arm64": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.3.tgz",
+			"integrity": "sha512-dRUZZrdwh1asfTOyM1nDNmzolhnHtlIFpqYrl1Tdd3YVcaebKmrfJgGL7NAoGPjbEwYmZxaugrxA0uzw83c0dw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@bruits/satteri-darwin-x64": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.3.tgz",
+			"integrity": "sha512-wgNCTRp2hPSpNMGFv5A4+6+VXgRJIlBZ7XKb3iwjV8YjRWNIjzE5zV2fUeYynyZYVRkuJ9aYFqQmWhc1e5H+UQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@bruits/satteri-linux-arm64-gnu": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.3.tgz",
+			"integrity": "sha512-A/pWy8Jb/PhDYc2/JFuYh06gFJcsfBUBDl81YydGYBrL/Z4nItDfhNDNOibyeSN/lKKDRlycIHEIajjErk00sQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@bruits/satteri-linux-arm64-musl": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.3.tgz",
+			"integrity": "sha512-L6YxmyOSickzo4pE5WmZfNTJnjX0MtgKOsuwQfNZECTx9Ir5vl2B37EIwnxe2AybuPPHl+FqVQtthNDUdH4Vgg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@bruits/satteri-linux-x64-gnu": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.3.tgz",
+			"integrity": "sha512-RgH6GPihg9Lzs2yHUsMjqiLxfLyOdmBty8sg9pBY9B4CBnvdOzvg8vklqN+C4qrEEdA9TwpbDpHr1AshLKyRpw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@bruits/satteri-linux-x64-musl": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.3.tgz",
+			"integrity": "sha512-BeWhVORjNTIomePznUKiMbHZTqC0j7sMXZFsISmbX+po5d33KLkqBqKh6K332CHJ8KUmCWx16FfPjwsoysttQg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@bruits/satteri-wasm32-wasi": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.3.tgz",
+			"integrity": "sha512-dFNcOHKWV2cztCPnYTn7kZ9D7kNOt8N239z5ysFkNHLxJrfK7zaKIXQbfXYN32C+JoVFqAcTIOeWH2+VnsCOHg==",
+			"cpu": [
+				"wasm32"
+			],
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@bruits/satteri-win32-arm64-msvc": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.3.tgz",
+			"integrity": "sha512-VnwjBHiAra/PNNEza8eSZdQiG4A3PtTJJwUDtOPAc6iTs0BWZwZX8+OPUZE7//yQCBhgvEMcI8vpwsAwCb6qGQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@bruits/satteri-win32-x64-msvc": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.3.tgz",
+			"integrity": "sha512-Dsoe4reWe69MyILmMwU6iISIceTW7YIFqbyym7haf9DhUvqkYfMAyp7GMM21JzV0SpG9A2BwzFVP7iq9mmxrpA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@capsizecss/unpack": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
@@ -603,10 +1432,39 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@clack/core": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+			"integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
+		"node_modules/@clack/prompts": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+			"integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+			"license": "MIT",
+			"dependencies": {
+				"@clack/core": "1.4.2",
+				"fast-string-width": "^3.0.2",
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
 		"node_modules/@emmetio/abbreviation": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
 			"integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emmetio/scanner": "^1.0.4"
@@ -616,6 +1474,7 @@
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
 			"integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emmetio/scanner": "^1.0.4"
@@ -625,6 +1484,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
 			"integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emmetio/stream-reader": "^2.2.0",
@@ -635,6 +1495,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
 			"integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@emmetio/scanner": "^1.0.0"
@@ -644,19 +1505,33 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
 			"integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emmetio/stream-reader": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
 			"integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emmetio/stream-reader-utils": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
 			"integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
 		},
 		"node_modules/@emnapi/runtime": {
 			"version": "1.11.1",
@@ -668,10 +1543,20 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -685,9 +1570,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
 			"cpu": [
 				"arm"
 			],
@@ -701,9 +1586,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -717,9 +1602,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
 			"cpu": [
 				"x64"
 			],
@@ -733,9 +1618,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -749,9 +1634,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -765,9 +1650,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -781,9 +1666,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -797,9 +1682,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
 			"cpu": [
 				"arm"
 			],
@@ -813,9 +1698,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -829,9 +1714,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
 			"cpu": [
 				"ia32"
 			],
@@ -845,9 +1730,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
 			"cpu": [
 				"loong64"
 			],
@@ -861,9 +1746,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -877,9 +1762,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -893,9 +1778,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -909,9 +1794,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
 			"cpu": [
 				"s390x"
 			],
@@ -925,9 +1810,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
 			"cpu": [
 				"x64"
 			],
@@ -941,9 +1826,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -957,9 +1842,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
 			"cpu": [
 				"x64"
 			],
@@ -973,9 +1858,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
 			"cpu": [
 				"arm64"
 			],
@@ -989,9 +1874,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
 			"cpu": [
 				"x64"
 			],
@@ -1005,9 +1890,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1021,9 +1906,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
 			"cpu": [
 				"x64"
 			],
@@ -1037,9 +1922,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1053,9 +1938,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1069,9 +1954,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
 			"cpu": [
 				"x64"
 			],
@@ -1598,63 +2483,6 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"license": "MIT"
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1733,6 +2561,24 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
 		"node_modules/@nodable/entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
@@ -1751,20 +2597,279 @@
 			"integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
 			"license": "MIT"
 		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+		"node_modules/@oxc-project/types": {
+			"version": "0.137.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+			"integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+			"integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
 			"optional": true,
+			"os": [
+				"android"
+			],
 			"engines": {
-				"node": ">=14"
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+			"integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+			"integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+			"integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+			"integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+			"integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+			"integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+			"integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+			"integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+			"integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+			"integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+			"integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+			"integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+			"integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+			"integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-beta.27",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-			"integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+			"version": "1.0.0-rc.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+			"integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -2158,7 +3263,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
 			"integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/primitive": "4.2.0",
 				"@shikijs/types": "4.2.0",
@@ -2175,7 +3279,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
 			"integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -2190,7 +3293,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
 			"integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
@@ -2204,7 +3306,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
 			"integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "4.2.0"
 			},
@@ -2217,7 +3318,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
 			"integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -2232,7 +3332,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
 			"integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "4.2.0"
 			},
@@ -2245,7 +3344,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
 			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
@@ -2264,6 +3362,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
 			"integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
@@ -2279,6 +3378,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
 			"integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
@@ -2305,6 +3405,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2321,6 +3422,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2337,6 +3439,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2353,6 +3456,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2369,6 +3473,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2385,6 +3490,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -2404,6 +3510,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -2423,6 +3530,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -2442,6 +3550,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -2469,6 +3578,7 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -2485,6 +3595,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
 			"version": "1.10.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -2495,6 +3606,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
 			"version": "1.10.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -2504,6 +3616,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -2513,6 +3626,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -2530,6 +3644,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -2539,6 +3654,7 @@
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
 			"version": "2.8.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "0BSD",
 			"optional": true
@@ -2550,6 +3666,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2566,6 +3683,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2592,6 +3710,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
 			"integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tailwindcss/node": "4.3.1",
@@ -2600,6 +3719,16 @@
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -2657,6 +3786,15 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"license": "MIT"
+		},
+		"node_modules/@types/estree-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
 		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
@@ -2740,14 +3878,15 @@
 			"license": "ISC"
 		},
 		"node_modules/@vercel/analytics": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
-			"integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
-			"license": "MPL-2.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+			"integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@remix-run/react": "^2",
 				"@sveltejs/kit": "^1 || ^2",
 				"next": ">= 13",
+				"nuxt": ">= 3",
 				"react": "^18 || ^19 || ^19.0.0-rc",
 				"svelte": ">= 4",
 				"vue": "^3",
@@ -2761,6 +3900,9 @@
 					"optional": true
 				},
 				"next": {
+					"optional": true
+				},
+				"nuxt": {
 					"optional": true
 				},
 				"react": {
@@ -2777,30 +3919,65 @@
 				}
 			}
 		},
-		"node_modules/@vercel/functions": {
-			"version": "2.2.13",
-			"resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-2.2.13.tgz",
-			"integrity": "sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==",
+		"node_modules/@vercel/cli-config": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+			"integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/oidc": "2.0.2"
+				"xdg-app-paths": "5",
+				"zod": "4.1.11"
+			}
+		},
+		"node_modules/@vercel/cli-config/node_modules/zod": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+			"integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@vercel/cli-exec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+			"integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"execa": "5.1.1"
 			},
 			"engines": {
 				"node": ">= 18"
+			}
+		},
+		"node_modules/@vercel/functions": {
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.7.4.tgz",
+			"integrity": "sha512-BvHqiuWziXaApV/eazLc84cHzEpPyNGG2UUAg82x+VN2VTCtX/DKH7SKOb3PxpRL/27zxPz8ltdO6GoKj66DaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@vercel/oidc": "3.7.1"
+			},
+			"engines": {
+				"node": ">= 20"
 			},
 			"peerDependencies": {
-				"@aws-sdk/credential-provider-web-identity": "*"
+				"@aws-sdk/credential-provider-web-identity": "*",
+				"ws": ">=8"
 			},
 			"peerDependenciesMeta": {
 				"@aws-sdk/credential-provider-web-identity": {
+					"optional": true
+				},
+				"ws": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@vercel/nft": {
-			"version": "0.30.4",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.30.4.tgz",
-			"integrity": "sha512-wE6eAGSXScra60N2l6jWvNtVK0m+sh873CpfZW4KI2v8EHuUQp+mSEi4T+IcdPCSEDgCdAS/7bizbhQlkjzrSA==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.2.tgz",
+			"integrity": "sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==",
 			"license": "MIT",
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^2.0.0",
@@ -2810,7 +3987,7 @@
 				"async-sema": "^3.1.1",
 				"bindings": "^1.4.0",
 				"estree-walker": "2.0.2",
-				"glob": "^10.5.0",
+				"glob": "^13.0.0",
 				"graceful-fs": "^4.2.9",
 				"node-gyp-build": "^4.2.2",
 				"picomatch": "^4.0.2",
@@ -2820,20 +3997,21 @@
 				"nft": "out/cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@vercel/oidc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-2.0.2.tgz",
-			"integrity": "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.7.1.tgz",
+			"integrity": "sha512-RrSsVWbq3KLK5lJobyTPp3tSthNfUp+zWkXno5Wkko0oEW05rA4ngOrnVypP4+L8/Av89uPo2rWFmzL8iwnsmA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@types/ms": "2.1.0",
-				"ms": "2.1.3"
+				"@vercel/cli-config": "0.2.0",
+				"@vercel/cli-exec": "1.0.0",
+				"jose": "^5.9.6"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@vercel/routing-utils": {
@@ -2850,29 +4028,30 @@
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-			"integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+			"integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.28.0",
+				"@babel/core": "^7.29.0",
 				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
 				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
-				"@rolldown/pluginutils": "1.0.0-beta.27",
+				"@rolldown/pluginutils": "1.0.0-rc.3",
 				"@types/babel__core": "^7.20.5",
-				"react-refresh": "^0.17.0"
+				"react-refresh": "^0.18.0"
 			},
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@volar/kit": {
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
 			"integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/language-service": "2.4.28",
@@ -2889,6 +4068,7 @@
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
 			"integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/source-map": "2.4.28"
@@ -2898,6 +4078,7 @@
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
 			"integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/language-core": "2.4.28",
@@ -2915,6 +4096,7 @@
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
 			"integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/language-core": "2.4.28",
@@ -2927,12 +4109,14 @@
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
 			"integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@volar/typescript": {
 			"version": "2.4.28",
 			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
 			"integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/language-core": "2.4.28",
@@ -2944,6 +4128,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
 			"integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emmet": "^2.4.3",
@@ -2957,6 +4142,7 @@
 			"version": "0.0.18",
 			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
 			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/abbrev": {
@@ -3015,78 +4201,16 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/ansi-align": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.1.0"
-			}
-		},
-		"node_modules/ansi-align/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-align/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"node_modules/ansi-align/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+		"node_modules/am-i-vibing": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+			"integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
+				"process-ancestry": "^0.1.0"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-align/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			"bin": {
+				"am-i-vibing": "dist/cli.mjs"
 			}
 		},
 		"node_modules/anymatch": {
@@ -3158,80 +4282,73 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "5.18.2",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
-			"integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-7.0.3.tgz",
+			"integrity": "sha512-CK+G+Tl2DMV1EXCwVG45vyurxf2IfRTklMxDhRKn+tst9Yl8rWXpudL62Fa6zin5Bt968FBvuyASj1aJShROZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/compiler": "^2.13.0",
-				"@astrojs/internal-helpers": "0.7.6",
-				"@astrojs/markdown-remark": "6.3.11",
-				"@astrojs/telemetry": "3.3.0",
+				"@astrojs/compiler-rs": "^0.2.2",
+				"@astrojs/internal-helpers": "0.10.0",
+				"@astrojs/markdown-satteri": "0.3.2",
+				"@astrojs/telemetry": "3.3.2",
 				"@capsizecss/unpack": "^4.0.0",
+				"@clack/prompts": "^1.1.0",
 				"@oslojs/encoding": "^1.1.0",
 				"@rollup/pluginutils": "^5.3.0",
-				"acorn": "^8.15.0",
+				"am-i-vibing": "^0.4.0",
 				"aria-query": "^5.3.2",
 				"axobject-query": "^4.1.0",
-				"boxen": "8.0.1",
-				"ci-info": "^4.3.1",
+				"ci-info": "^4.4.0",
 				"clsx": "^2.1.1",
-				"common-ancestor-path": "^1.0.1",
+				"common-ancestor-path": "^2.0.0",
 				"cookie": "^1.1.1",
-				"cssesc": "^3.0.0",
-				"debug": "^4.4.3",
-				"deterministic-object-hash": "^2.0.2",
-				"devalue": "^5.6.2",
+				"devalue": "^5.8.1",
 				"diff": "^8.0.3",
-				"dlv": "^1.1.3",
 				"dset": "^3.1.4",
-				"es-module-lexer": "^1.7.0",
-				"esbuild": "^0.27.3",
-				"estree-walker": "^3.0.3",
+				"es-module-lexer": "^2.0.0",
+				"esbuild": "^0.28.0",
 				"flattie": "^1.1.1",
-				"fontace": "~0.4.0",
+				"fontace": "~0.4.1",
+				"get-tsconfig": "5.0.0-beta.4",
 				"github-slugger": "^2.0.0",
 				"html-escaper": "3.0.3",
 				"http-cache-semantics": "^4.2.0",
-				"import-meta-resolve": "^4.2.0",
 				"js-yaml": "^4.1.1",
+				"jsonc-parser": "^3.3.1",
 				"magic-string": "^0.30.21",
-				"magicast": "^0.5.1",
+				"magicast": "^0.5.2",
 				"mrmime": "^2.0.1",
 				"neotraverse": "^0.6.18",
-				"p-limit": "^6.2.0",
-				"p-queue": "^8.1.1",
+				"obug": "^2.1.1",
+				"p-limit": "^7.3.0",
+				"p-queue": "^9.1.0",
 				"package-manager-detector": "^1.6.0",
 				"piccolore": "^0.1.3",
-				"picomatch": "^4.0.3",
-				"prompts": "^2.4.2",
+				"picomatch": "^4.0.4",
 				"rehype": "^13.0.2",
-				"semver": "^7.7.3",
-				"shiki": "^3.21.0",
+				"semver": "^7.7.4",
+				"shiki": "^4.0.2",
 				"smol-toml": "^1.6.0",
-				"svgo": "^4.0.0",
-				"tinyexec": "^1.0.2",
+				"svgo": "^4.0.1",
+				"tinyclip": "^0.1.12",
+				"tinyexec": "^1.0.4",
 				"tinyglobby": "^0.2.15",
-				"tsconfck": "^3.1.6",
 				"ultrahtml": "^1.6.0",
-				"unifont": "~0.7.3",
-				"unist-util-visit": "^5.0.0",
-				"unstorage": "^1.17.4",
+				"unifont": "~0.7.4",
+				"unist-util-visit": "^5.1.0",
+				"unstorage": "^1.17.5",
 				"vfile": "^6.0.3",
-				"vite": "^6.4.1",
-				"vitefu": "^1.1.1",
+				"vite": "^8.0.13",
+				"vitefu": "^1.1.2",
 				"xxhash-wasm": "^1.1.0",
-				"yargs-parser": "^21.1.1",
-				"yocto-spinner": "^0.2.3",
-				"zod": "^3.25.76",
-				"zod-to-json-schema": "^3.25.1",
-				"zod-to-ts": "^1.2.0"
+				"yargs-parser": "^22.0.0",
+				"zod": "^4.3.6"
 			},
 			"bin": {
-				"astro": "astro.js"
+				"astro": "bin/astro.mjs"
 			},
 			"engines": {
-				"node": "18.20.8 || ^20.3.0 || >=22.0.0",
+				"node": ">=22.12.0",
 				"npm": ">=9.6.5",
 				"pnpm": ">=7.1.0"
 			},
@@ -3241,12 +4358,20 @@
 			},
 			"optionalDependencies": {
 				"sharp": "^0.34.0"
+			},
+			"peerDependencies": {
+				"@astrojs/markdown-remark": "7.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@astrojs/markdown-remark": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3260,9 +4385,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/android-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3276,9 +4401,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3292,9 +4417,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/android-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -3308,9 +4433,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3324,9 +4449,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3340,9 +4465,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3356,9 +4481,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3372,9 +4497,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3388,9 +4513,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -3404,9 +4529,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -3420,9 +4545,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -3436,9 +4561,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -3452,9 +4577,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3468,9 +4593,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3484,9 +4609,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -3500,9 +4625,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -3516,9 +4641,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3532,9 +4657,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -3548,9 +4673,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3564,9 +4689,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -3580,9 +4705,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3596,9 +4721,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3612,9 +4737,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3628,9 +4753,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -3644,9 +4769,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -3659,71 +4784,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/astro/node_modules/@shikijs/core": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.5"
-			}
-		},
-		"node_modules/astro/node_modules/@shikijs/engine-javascript": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-			"integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^4.3.4"
-			}
-		},
-		"node_modules/astro/node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"node_modules/astro/node_modules/@shikijs/langs": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0"
-			}
-		},
-		"node_modules/astro/node_modules/@shikijs/themes": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.23.0"
-			}
-		},
-		"node_modules/astro/node_modules/@shikijs/types": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
 		"node_modules/astro/node_modules/esbuild": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -3733,75 +4797,124 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.7",
-				"@esbuild/android-arm": "0.27.7",
-				"@esbuild/android-arm64": "0.27.7",
-				"@esbuild/android-x64": "0.27.7",
-				"@esbuild/darwin-arm64": "0.27.7",
-				"@esbuild/darwin-x64": "0.27.7",
-				"@esbuild/freebsd-arm64": "0.27.7",
-				"@esbuild/freebsd-x64": "0.27.7",
-				"@esbuild/linux-arm": "0.27.7",
-				"@esbuild/linux-arm64": "0.27.7",
-				"@esbuild/linux-ia32": "0.27.7",
-				"@esbuild/linux-loong64": "0.27.7",
-				"@esbuild/linux-mips64el": "0.27.7",
-				"@esbuild/linux-ppc64": "0.27.7",
-				"@esbuild/linux-riscv64": "0.27.7",
-				"@esbuild/linux-s390x": "0.27.7",
-				"@esbuild/linux-x64": "0.27.7",
-				"@esbuild/netbsd-arm64": "0.27.7",
-				"@esbuild/netbsd-x64": "0.27.7",
-				"@esbuild/openbsd-arm64": "0.27.7",
-				"@esbuild/openbsd-x64": "0.27.7",
-				"@esbuild/openharmony-arm64": "0.27.7",
-				"@esbuild/sunos-x64": "0.27.7",
-				"@esbuild/win32-arm64": "0.27.7",
-				"@esbuild/win32-ia32": "0.27.7",
-				"@esbuild/win32-x64": "0.27.7"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
-		"node_modules/astro/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+		"node_modules/astro/node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"license": "MIT"
+		},
+		"node_modules/astro/node_modules/vite": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+			"integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/astro/node_modules/shiki": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-			"integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/core": "3.23.0",
-				"@shikijs/engine-javascript": "3.23.0",
-				"@shikijs/engine-oniguruma": "3.23.0",
-				"@shikijs/langs": "3.23.0",
-				"@shikijs/themes": "3.23.0",
-				"@shikijs/types": "3.23.0",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
-		"node_modules/astro/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.15",
+				"rolldown": "~1.1.2",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
 			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/astro/node_modules/zod-to-ts": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-			"integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-			"peerDependencies": {
-				"typescript": "^4.9.4 || ^5.0.2",
-				"zod": "^3"
+		"node_modules/astro/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/async-sema": {
@@ -3830,21 +4943,18 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
-		},
-		"node_modules/base-64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.38",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+			"version": "2.10.40",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+			"integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -3868,41 +4978,22 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"license": "ISC"
 		},
-		"node_modules/boxen": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-			"integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+		"node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-align": "^3.0.1",
-				"camelcase": "^8.0.0",
-				"chalk": "^5.3.0",
-				"cli-boxes": "^3.0.0",
-				"string-width": "^7.2.0",
-				"type-fest": "^4.21.0",
-				"widest-line": "^5.0.0",
-				"wrap-ansi": "^9.0.0"
+				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+			"integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3919,10 +5010,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
+				"baseline-browser-mapping": "^2.10.38",
+				"caniuse-lite": "^1.0.30001799",
+				"electron-to-chromium": "^1.5.376",
+				"node-releases": "^2.0.48",
 				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
@@ -3930,18 +5021,6 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/camelcase": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -3984,18 +5063,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/character-entities": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4030,6 +5097,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"readdirp": "^4.0.1"
@@ -4065,22 +5133,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cli-boxes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-			"integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -4095,6 +5152,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4104,6 +5162,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -4119,12 +5178,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cliui/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -4139,6 +5200,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -4151,6 +5213,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -4177,6 +5240,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4189,6 +5253,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/comma-separated-tokens": {
@@ -4211,10 +5276,13 @@
 			}
 		},
 		"node_modules/common-ancestor-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-			"integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-			"license": "ISC"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+			"integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">= 18"
+			}
 		},
 		"node_modules/consola": {
 			"version": "3.4.2",
@@ -4318,6 +5386,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -4425,18 +5494,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/deterministic-object-hash": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-			"integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"base-64": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/devalue": {
 			"version": "5.8.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
@@ -4464,12 +5521,6 @@
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/dlv": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -4547,22 +5598,17 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"license": "MIT"
-		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.376",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-			"integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+			"version": "1.5.380",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+			"integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
 			"license": "ISC"
 		},
 		"node_modules/emmet": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
 			"integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+			"dev": true,
 			"license": "MIT",
 			"workspaces": [
 				"./packages/scanner",
@@ -4575,16 +5621,11 @@
 				"@emmetio/css-abbreviation": "^2.1.8"
 			}
 		},
-		"node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"license": "MIT"
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.21.6",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
 			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -4607,15 +5648,15 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -4625,32 +5666,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.12",
-				"@esbuild/android-arm": "0.25.12",
-				"@esbuild/android-arm64": "0.25.12",
-				"@esbuild/android-x64": "0.25.12",
-				"@esbuild/darwin-arm64": "0.25.12",
-				"@esbuild/darwin-x64": "0.25.12",
-				"@esbuild/freebsd-arm64": "0.25.12",
-				"@esbuild/freebsd-x64": "0.25.12",
-				"@esbuild/linux-arm": "0.25.12",
-				"@esbuild/linux-arm64": "0.25.12",
-				"@esbuild/linux-ia32": "0.25.12",
-				"@esbuild/linux-loong64": "0.25.12",
-				"@esbuild/linux-mips64el": "0.25.12",
-				"@esbuild/linux-ppc64": "0.25.12",
-				"@esbuild/linux-riscv64": "0.25.12",
-				"@esbuild/linux-s390x": "0.25.12",
-				"@esbuild/linux-x64": "0.25.12",
-				"@esbuild/netbsd-arm64": "0.25.12",
-				"@esbuild/netbsd-x64": "0.25.12",
-				"@esbuild/openbsd-arm64": "0.25.12",
-				"@esbuild/openbsd-x64": "0.25.12",
-				"@esbuild/openharmony-arm64": "0.25.12",
-				"@esbuild/sunos-x64": "0.25.12",
-				"@esbuild/win32-arm64": "0.25.12",
-				"@esbuild/win32-ia32": "0.25.12",
-				"@esbuild/win32-x64": "0.25.12"
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
 		"node_modules/escalade": {
@@ -4686,6 +5727,29 @@
 			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"license": "MIT"
 		},
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4696,6 +5760,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -4705,10 +5770,26 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
 			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4720,6 +5801,15 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.2.0",
@@ -4813,22 +5903,6 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4856,21 +5930,37 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+		"node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "5.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+			"integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.20.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/github-slugger": {
@@ -4880,21 +5970,17 @@
 			"license": "ISC"
 		},
 		"node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -5148,14 +6234,13 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/import-meta-resolve": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/iron-webcrypto": {
@@ -5168,15 +6253,15 @@
 			}
 		},
 		"node_modules/is-docker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+			"integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
 			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5186,6 +6271,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5209,6 +6295,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-plain-obj": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -5216,6 +6317,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5254,28 +6367,23 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
 		"node_modules/jiti": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
 			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/jose": {
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+			"integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-tokens": {
@@ -5285,9 +6393,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -5341,12 +6449,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
 			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
 			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5892,6 +7002,12 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"license": "CC0-1.0"
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"license": "MIT"
 		},
 		"node_modules/micromark": {
 			"version": "4.0.2",
@@ -6456,16 +7572,25 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"license": "ISC",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -6511,6 +7636,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
 			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
@@ -6597,9 +7723,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.48",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-			"integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+			"version": "2.0.50",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+			"integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -6629,6 +7755,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -6639,6 +7777,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/ofetch": {
@@ -6658,6 +7809,21 @@
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
 			"license": "MIT"
 		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/oniguruma-parser": {
 			"version": "0.12.2",
 			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -6675,54 +7841,57 @@
 				"regex-recursion": "^6.0.2"
 			}
 		},
+		"node_modules/os-paths": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+			"integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0"
+			}
+		},
 		"node_modules/p-limit": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-			"integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+			"integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
 			"license": "MIT",
 			"dependencies": {
-				"yocto-queue": "^1.1.1"
+				"yocto-queue": "^1.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-queue": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-			"integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+			"integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
 			"license": "MIT",
 			"dependencies": {
-				"eventemitter3": "^5.0.1",
-				"p-timeout": "^6.1.2"
+				"eventemitter3": "^5.0.4",
+				"p-timeout": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
 			"version": "1.6.0",
@@ -6770,6 +7939,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
 			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-expression-matcher": {
@@ -6797,26 +7967,29 @@
 			}
 		},
 		"node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.18"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.1.0",
@@ -6901,6 +8074,7 @@
 			"version": "3.8.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
 			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -6916,7 +8090,7 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
 			"integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/compiler": "^2.9.1",
@@ -7015,26 +8189,13 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"license": "MIT",
-			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/prompts/node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+		"node_modules/process-ancestry": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+			"integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/property-information": {
@@ -7085,9 +8246,9 @@
 			}
 		},
 		"node_modules/react-refresh": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-			"integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+			"integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7097,6 +8258,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
 			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.18.0"
@@ -7302,12 +8464,14 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
 			"integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7317,6 +8481,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7329,6 +8494,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
 		},
 		"node_modules/retext": {
@@ -7392,6 +8566,45 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+			"integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.137.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.3",
+				"@rolldown/binding-darwin-arm64": "1.1.3",
+				"@rolldown/binding-darwin-x64": "1.1.3",
+				"@rolldown/binding-freebsd-x64": "1.1.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.3",
+				"@rolldown/binding-linux-arm64-musl": "1.1.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.3",
+				"@rolldown/binding-linux-x64-gnu": "1.1.3",
+				"@rolldown/binding-linux-x64-musl": "1.1.3",
+				"@rolldown/binding-openharmony-arm64": "1.1.3",
+				"@rolldown/binding-wasm32-wasi": "1.1.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.3",
+				"@rolldown/binding-win32-x64-msvc": "1.1.3"
+			}
+		},
+		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"license": "MIT"
+		},
 		"node_modules/rollup": {
 			"version": "4.62.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -7440,17 +8653,39 @@
 			"version": "0.0.15",
 			"resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
 			"integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sass-formatter": {
 			"version": "0.7.9",
 			"resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
 			"integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"suf-log": "^2.5.3"
+			}
+		},
+		"node_modules/satteri": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.3.tgz",
+			"integrity": "sha512-2XfBh89LCnBMFkNOeVKkBLelAZcIA17VLHsgJum1tJ2fXiPZDN/TDXv4ku46rFOQXYd41LJ0kiZh5gPqExcCsg==",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.5",
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"@types/unist": "^3.0.3"
+			},
+			"optionalDependencies": {
+				"@bruits/satteri-darwin-arm64": "0.9.3",
+				"@bruits/satteri-darwin-x64": "0.9.3",
+				"@bruits/satteri-linux-arm64-gnu": "0.9.3",
+				"@bruits/satteri-linux-arm64-musl": "0.9.3",
+				"@bruits/satteri-linux-x64-gnu": "0.9.3",
+				"@bruits/satteri-linux-x64-musl": "0.9.3",
+				"@bruits/satteri-wasm32-wasi": "0.9.3",
+				"@bruits/satteri-win32-arm64-msvc": "0.9.3",
+				"@bruits/satteri-win32-x64-msvc": "0.9.3"
 			}
 		},
 		"node_modules/sax": {
@@ -7551,7 +8786,6 @@
 			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
 			"integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@shikijs/core": "4.2.0",
 				"@shikijs/engine-javascript": "4.2.0",
@@ -7567,16 +8801,10 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
 		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
@@ -7640,65 +8868,6 @@
 			"integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
 			"license": "MIT"
 		},
-		"node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7713,41 +8882,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=6"
 			}
 		},
 		"node_modules/strnum": {
@@ -7769,7 +8910,7 @@
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
 			"integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"s.color": "0.0.15"
@@ -7804,12 +8945,14 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
 			"integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
 			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -7820,9 +8963,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.16",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-			"integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+			"version": "7.5.19",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -7849,6 +8992,15 @@
 			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
 			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
 			"license": "MIT"
+		},
+		"node_modules/tinyclip": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+			"integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+			"license": "MIT",
+			"engines": {
+				"node": "^16.14.0 || >= 17.3.0"
+			}
 		},
 		"node_modules/tinyexec": {
 			"version": "1.2.4",
@@ -7901,27 +9053,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/tsconfck": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-			"integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-			"deprecated": "unmaintained",
-			"license": "MIT",
-			"bin": {
-				"tsconfck": "bin/tsconfck.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			},
-			"peerDependencies": {
-				"typescript": "^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7929,28 +9060,18 @@
 			"license": "0BSD",
 			"optional": true
 		},
-		"node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/typesafe-path": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
 			"integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -7964,6 +9085,7 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
 			"integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.8"
@@ -8369,23 +9491,23 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
-			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.25.0",
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2",
-				"postcss": "^8.5.3",
-				"rollup": "^4.34.9",
-				"tinyglobby": "^0.2.13"
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -8394,14 +9516,14 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@types/node": "^20.19.0 || >=22.12.0",
 				"jiti": ">=1.21.0",
-				"less": "*",
+				"less": "^4.0.0",
 				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
 				"terser": "^5.16.0",
 				"tsx": "^4.8.1",
 				"yaml": "^2.4.2"
@@ -8465,6 +9587,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
 			"integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-css-languageservice": "^6.3.0",
@@ -8484,6 +9607,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
 			"integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emmetio/css-parser": "^0.4.1",
@@ -8504,6 +9628,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
 			"integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-html-languageservice": "^5.3.0",
@@ -8523,6 +9648,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
 			"integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-uri": "^3.0.8"
@@ -8544,6 +9670,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
 			"integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-browserify": "^1.0.1",
@@ -8566,6 +9693,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
 			"integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-uri": "^3.0.8"
@@ -8583,6 +9711,7 @@
 			"version": "0.0.70",
 			"resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
 			"integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-uri": "^3.0.8",
@@ -8601,6 +9730,7 @@
 			"version": "6.3.10",
 			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
 			"integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
@@ -8613,12 +9743,14 @@
 			"version": "3.17.5",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
 			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-html-languageservice": {
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
 			"integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
@@ -8631,6 +9763,7 @@
 			"version": "4.1.8",
 			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
 			"integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.0.0",
@@ -8647,12 +9780,14 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-jsonrpc": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
 			"integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -8662,6 +9797,7 @@
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
 			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageserver-protocol": "3.17.5"
@@ -8674,6 +9810,7 @@
 			"version": "3.18.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
 			"integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "9.0.0",
@@ -8684,18 +9821,21 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
 			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.18.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
 			"integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
 			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -8705,6 +9845,7 @@
 			"version": "3.17.5",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
 			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "8.2.0",
@@ -8715,18 +9856,21 @@
 			"version": "3.17.5",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
 			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-nls": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
 			"integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
 			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/web-namespaces": {
@@ -8779,110 +9923,29 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/widest-line": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-			"integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+		"node_modules/xdg-app-paths": {
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+			"integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
 			"license": "MIT",
 			"dependencies": {
-				"string-width": "^7.0.0"
+				"os-paths": "^4.0.1",
+				"xdg-portable": "^7.2.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">= 6.0"
 			}
 		},
-		"node_modules/wrap-ansi": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+		"node_modules/xdg-portable": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+			"integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
+				"os-paths": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">= 6.0"
 			}
 		},
 		"node_modules/xml-naming": {
@@ -8910,6 +9973,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -8925,6 +9989,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"devOptional": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -8940,6 +10005,7 @@
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
 			"integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
@@ -8962,6 +10028,7 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -8978,6 +10045,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
 			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"ajv": "^8.5.0"
@@ -8992,18 +10060,21 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yaml-language-server/node_modules/request-light": {
 			"version": "0.5.8",
 			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
 			"integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yaml-language-server/node_modules/yaml": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
 			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -9016,6 +10087,7 @@
 			"version": "17.7.3",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
 			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -9034,6 +10106,7 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -9043,6 +10116,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9052,12 +10126,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yargs/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -9072,6 +10148,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9092,33 +10169,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/yocto-spinner": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-			"integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"yoctocolors": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=18.19"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/zod": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -9126,15 +10176,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -10,29 +10,31 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/check": "0.9.9",
-		"@astrojs/react": "4.4.2",
+		"@astrojs/markdown-remark": "7.2.0",
+		"@astrojs/react": "6.0.0",
 		"@astrojs/rss": "4.0.18",
 		"@astrojs/sitemap": "3.7.3",
-		"@astrojs/vercel": "9.0.5",
-		"@tailwindcss/vite": "4.3.1",
-		"@types/react": "19.2.17",
-		"@types/react-dom": "19.2.3",
-		"@vercel/analytics": "1.6.1",
-		"astro": "5.18.2",
+		"@astrojs/vercel": "11.0.0",
+		"@vercel/analytics": "2.0.1",
+		"astro": "7.0.3",
 		"canvas-confetti": "1.9.4",
 		"mdast-util-to-string": "4.0.0",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
 		"reading-time": "1.5.0",
-		"rehype-pretty-code": "0.14.3",
-		"tailwindcss": "4.3.1",
-		"typescript": "5.9.3"
+		"rehype-pretty-code": "0.14.3"
 	},
 	"devDependencies": {
+		"@astrojs/check": "0.9.9",
 		"@tailwindcss/typography": "0.5.20",
+		"@tailwindcss/vite": "4.3.1",
+		"@types/react": "19.2.17",
+		"@types/react-dom": "19.2.3",
 		"prettier": "3.8.4",
 		"prettier-plugin-astro": "0.14.1",
-		"prettier-plugin-tailwindcss": "0.8.0"
+		"prettier-plugin-tailwindcss": "0.8.0",
+		"tailwindcss": "4.3.1",
+		"typescript": "6.0.3",
+		"vite": "7.3.3"
 	}
 }


### PR DESCRIPTION
This PR restores the broken CI workflow and consolidates multiple pending major updates into a single consistent state. 

Key changes:
1. **CI Restoration**: Re-created `.github/workflows/ci.yml` using Node.js 22 and the project's standard build pipeline.
2. **Dependency Consolidation**: 
   - Updated `astro` to `7.0.3`.
   - Updated `@astrojs/react` to `6.0.0`.
   - Updated `typescript` to `6.0.3`.
   - Updated `@astrojs/vercel` to `11.0.0`.
   - Updated `@vercel/analytics` to `2.0.1`.
3. **Configuration Update**: Migrated the markdown configuration in `astro.config.mjs` to use the `markdown.processor` API introduced in Astro 6.4, ensuring compatibility with the new major versions.
4. **Environment Stability**: Pinned `vite` to `7.3.3` to prevent known build failures with `tailwindcss` @ 4.3.1.
5. **Project Hygiene**: Moved development-only packages (`typescript`, `vite`, `@astrojs/check`, etc.) to `devDependencies`.

Local verification confirmed that `npm run build` (including `astro check`) passes successfully and the frontend renders correctly.

---
*PR created automatically by Jules for task [1797435406829670743](https://jules.google.com/task/1797435406829670743) started by @nicdun*