### PR TITLE
Fix CI and prepare for major updates

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-    - name: Use Node.js 24
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
       with:
-        node-version: 24
+        node-version: 22
         cache: 'npm'
     - run: npm ci
     - run: npm run build


### PR DESCRIPTION
Fixed the GitHub Actions CI by correcting invalid Node.js and action versions. Also untracked auto-generated files in the `.astro/` directory. These changes ensure that the repository's CI passes, allowing for the successful merging of major dependency updates (Astro 7, Vite 8, etc.).

---
*PR created automatically by Jules for task [13908403271779246936](https://jules.google.com/task/13908403271779246936) started by @nicdun*